### PR TITLE
feat: set min instances to 2 and fix bug with outdated tasks being processed

### DIFF
--- a/backend/functions/src/core/questionCore.ts
+++ b/backend/functions/src/core/questionCore.ts
@@ -1,31 +1,7 @@
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
-import { randomBytes } from 'crypto';
 import { ALL_LVLS, LVL_EASY, LVL_MEDIUM, LVL_HARD } from '../consts/values';
-
-// Adapted from https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/util/misc.ts
-function autoId(): string {
-  // Alphanumeric characters
-  const chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  // The largest byte value that is a multiple of `char.length`.
-  const maxMultiple = Math.floor(256 / chars.length) * chars.length;
-
-  let autoId = '';
-  const targetLength = 20;
-  while (autoId.length < targetLength) {
-    const bytes = randomBytes(40);
-    for (let i = 0; i < bytes.length; ++i) {
-      // Only accept values that are [0, maxMultiple), this ensures they can
-      // be evenly mapped to indices of `chars` via a modulo operation.
-      if (autoId.length < targetLength && bytes[i] < maxMultiple) {
-        autoId += chars.charAt(bytes[i] % chars.length);
-      }
-    }
-  }
-
-  return autoId;
-}
+import autoId from '../util/autoId';
 
 export async function getRandomQuestion(level: string): Promise<string> {
   // See https://stackoverflow.com/questions/46798981/firestore-how-to-get-random-documents-in-a-collection for more info

--- a/backend/functions/src/core/queueCore.ts
+++ b/backend/functions/src/core/queueCore.ts
@@ -133,5 +133,3 @@ export async function getMatchTimeoutTask(userId: string): Promise<any> {
     await firestore.doc(`matchTimeoutTasks/${userId}`).get()
   ).data()) as any;
 }
-
-// export async function removeUnmatchedUserAfterTimeout

--- a/backend/functions/src/core/queueCore.ts
+++ b/backend/functions/src/core/queueCore.ts
@@ -50,6 +50,9 @@ export async function removeUserFromQueue(
     await admin.database().ref(`/queues/${queueName}`).set(queue);
   }
 
+  // Remove matchTimeoutTask if present
+  await removeMatchTimeoutTask(uid);
+
   return;
 }
 
@@ -83,10 +86,11 @@ export async function addUserToQueue(
   await queuePath.set(queue);
 
   if (!RUNNING_IN_EMULATOR) {
-    await addUserToTimeoutQueue({
+    const task = await addUserToTimeoutQueue({
       userId: uid,
       queueName: queueName,
     });
+    await recordMatchTimeoutTask(task.id, uid);
   }
 
   functions.logger.log(`Successfully added user ${uid} to ${queueName} queue`);
@@ -109,3 +113,25 @@ export async function getQueueUserIsIn(uid: string): Promise<string | null> {
 
   return null;
 }
+
+export async function recordMatchTimeoutTask(
+  taskId: string,
+  userId: string
+): Promise<void> {
+  const firestore = admin.firestore();
+  await firestore.doc(`matchTimeoutTasks/${userId}`).set({ taskId });
+}
+
+export async function removeMatchTimeoutTask(userId: string): Promise<void> {
+  const firestore = admin.firestore();
+  await firestore.doc(`matchTimeoutTasks/${userId}`).delete();
+}
+
+export async function getMatchTimeoutTask(userId: string): Promise<any> {
+  const firestore = admin.firestore();
+  return (await (
+    await firestore.doc(`matchTimeoutTasks/${userId}`).get()
+  ).data()) as any;
+}
+
+// export async function removeUnmatchedUserAfterTimeout

--- a/backend/functions/src/functionBuilder.ts
+++ b/backend/functions/src/functionBuilder.ts
@@ -1,0 +1,9 @@
+import * as functions from 'firebase-functions';
+import { FUNCTION_LOCATION } from './consts/values';
+
+const functionBuilder = functions.region(FUNCTION_LOCATION).runWith({
+  timeoutSeconds: 180,
+  minInstances: 1,
+});
+
+export default functionBuilder;

--- a/backend/functions/src/functionBuilder.ts
+++ b/backend/functions/src/functionBuilder.ts
@@ -3,7 +3,7 @@ import { FUNCTION_LOCATION } from './consts/values';
 
 const functionBuilder = functions.region(FUNCTION_LOCATION).runWith({
   timeoutSeconds: 180,
-  minInstances: 1,
+  minInstances: 2,
 });
 
 export default functionBuilder;

--- a/backend/functions/src/functionBuilder.ts
+++ b/backend/functions/src/functionBuilder.ts
@@ -1,9 +1,12 @@
 import * as functions from 'firebase-functions';
 import { FUNCTION_LOCATION } from './consts/values';
 
+// Set back to its default value
+const minInstances = functions.config()?.peerprep?.mininstances ?? undefined;
+
 const functionBuilder = functions.region(FUNCTION_LOCATION).runWith({
   timeoutSeconds: 180,
-  minInstances: 2,
+  minInstances,
 });
 
 export default functionBuilder;

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -5,7 +5,7 @@ import * as matches from './matches';
 import * as questions from './questions';
 import * as queues from './queues';
 import * as sessions from './sessions';
-import { FUNCTION_LOCATION } from './consts/values';
+import functionBuilder from './functionBuilder';
 
 admin.initializeApp();
 
@@ -13,11 +13,11 @@ admin.initializeApp();
 // // https://firebase.google.com/docs/functions/typescript
 //
 
-export const helloWorld = functions
-  .region(FUNCTION_LOCATION)
-  .https.onRequest((request, response) => {
+export const helloWorld = functionBuilder.https.onRequest(
+  (request, response) => {
     functions.logger.info('Hello logs!', { structuredData: true });
     response.send('Hello from Firebase!');
-  });
+  }
+);
 
 export { matches, questions, queues, sessions };

--- a/backend/functions/src/matches.ts
+++ b/backend/functions/src/matches.ts
@@ -1,10 +1,10 @@
 import * as functions from 'firebase-functions';
-import { FUNCTION_LOCATION } from './consts/values';
 import * as matchingCore from './core/matchingCore';
 
-export const detectMatchesCreateSession = functions
-  .region(FUNCTION_LOCATION)
-  .database.ref('/queues/{difficulty}')
+import functionBuilder from './functionBuilder';
+
+export const detectMatchesCreateSession = functionBuilder.database
+  .ref('/queues/{difficulty}')
   .onWrite(async (change, context) => {
     const lvl = context.params.difficulty;
     const queueState = change.after.val() as string[];

--- a/backend/functions/src/questions.ts
+++ b/backend/functions/src/questions.ts
@@ -1,22 +1,20 @@
 import * as functions from 'firebase-functions';
 import * as questionCore from './core/questionCore';
 import { CallableContext } from 'firebase-functions/v1/https';
-import { FUNCTION_LOCATION } from './consts/values';
+import functionBuilder from './functionBuilder';
 
-export const getQuestion = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(
-    async (data: App.getQuestionData, _context: CallableContext) => {
-      // data: { "qnsId": "two-sum" }
+export const getQuestion = functionBuilder.https.onCall(
+  async (data: App.getQuestionData, _context: CallableContext) => {
+    // data: { "qnsId": "two-sum" }
 
-      if (!data || !data.qnsId || data.qnsId.length === 0) {
-        throw new functions.https.HttpsError(
-          'invalid-argument',
-          'The function must be called with ' +
-            'one argument "qnsId", the title slug of the question.'
-        );
-      }
-
-      return await questionCore.getQuestion(data.qnsId);
+    if (!data || !data.qnsId || data.qnsId.length === 0) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'The function must be called with ' +
+          'one argument "qnsId", the title slug of the question.'
+      );
     }
-  );
+
+    return await questionCore.getQuestion(data.qnsId);
+  }
+);

--- a/backend/functions/src/queues.ts
+++ b/backend/functions/src/queues.ts
@@ -32,12 +32,15 @@ export const removeUserFromQueue = functionBuilder.https.onCall(
 // This function will be called by Cloud Tasks so we use onRequest.
 export const removeUnmatchedUserAfterTimeout = functionBuilder.https.onRequest(
   async (req: functions.Request, res: functions.Response) => {
+    // The status should be all 200 or else the task will automatically be retried.
+    // We are using the same error format as functions.https.HttpsError to be consistent
+
     functions.logger.info(`Received parameters ${JSON.stringify(req.body)}`);
 
     const data = req.body.data;
 
     if (!data || !data.userId || !data.queueName) {
-      res.status(400).json({
+      res.status(200).json({
         code: 'invalid-argument',
         message:
           'The function must be called with two arguments queueName and userId.',
@@ -45,13 +48,33 @@ export const removeUnmatchedUserAfterTimeout = functionBuilder.https.onRequest(
       return;
     }
 
-    // If user is in a session, do nothing
     const userId = data.userId;
+    const matchTimeoutTask = await queueCore.getMatchTimeoutTask(userId);
+
+    // Make sure that the task is not outdated
+    if (
+      !matchTimeoutTask ||
+      (matchTimeoutTask && matchTimeoutTask.taskId !== data.taskId)
+    ) {
+      const msg = `Received outdated task for user ${userId}. Aborting`;
+      functions.logger.info(msg);
+      res.status(200).json({
+        code: 'failed-precondition',
+        message: msg,
+      });
+      return;
+    }
+
+    // Remove task that is going to be processed
+    await queueCore.removeMatchTimeoutTask(userId);
+
+    // If user is in a session, do nothing
     const isUserInSession = await isInCurrentSession(userId);
     if (isUserInSession) {
       const msg = `User ${userId} is already in a session and will not be removed from the queue`;
       functions.logger.info(msg);
       res.status(200).json({
+        code: 'failed-precondition',
         message: msg,
       });
       return;
@@ -60,7 +83,7 @@ export const removeUnmatchedUserAfterTimeout = functionBuilder.https.onRequest(
     // If the user is not in a session, remove them from the queue
     const queueName = queueCore.validateAndGetLevel(data);
     if ((await queueCore.getQueueUserIsIn(userId)) !== queueName) {
-      res.status(400).json({
+      res.status(200).json({
         code: 'failed-precondition',
         message: `UserId ${userId} is not in ${queueName} queue`,
       });

--- a/backend/functions/src/queues.ts
+++ b/backend/functions/src/queues.ts
@@ -1,38 +1,37 @@
 import * as functions from 'firebase-functions';
+import * as queueCore from './core/queueCore';
+
 import { CallableContext } from 'firebase-functions/v1/https';
 import { validateAndGetUid } from './core/authCore';
 import { isInCurrentSession } from './core/sessionCore';
 import { sendMessage } from './core/msgCore';
 import { NO_MATCH_FOUND } from './consts/msgTypes';
-import * as queueCore from './core/queueCore';
-import { FUNCTION_LOCATION, SUCCESS_RESP } from './consts/values';
+import { SUCCESS_RESP } from './consts/values';
+import functionBuilder from './functionBuilder';
 
-export const addUserToQueue = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: App.addUserToQueue, context: CallableContext) => {
+export const addUserToQueue = functionBuilder.https.onCall(
+  async (data: App.addUserToQueue, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const queueName = queueCore.validateAndGetLevel(data);
 
     await queueCore.addUserToQueue(uid, queueName);
     return SUCCESS_RESP;
-  });
+  }
+);
 
-export const removeUserFromQueue = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(
-    async (data: App.removeUserFromQueue, context: CallableContext) => {
-      const uid = validateAndGetUid(context);
-      const queueName = queueCore.validateAndGetLevel(data);
+export const removeUserFromQueue = functionBuilder.https.onCall(
+  async (data: App.removeUserFromQueue, context: CallableContext) => {
+    const uid = validateAndGetUid(context);
+    const queueName = queueCore.validateAndGetLevel(data);
 
-      await queueCore.removeUserFromQueue(uid, queueName);
-      return SUCCESS_RESP;
-    }
-  );
+    await queueCore.removeUserFromQueue(uid, queueName);
+    return SUCCESS_RESP;
+  }
+);
 
 // This function will be called by Cloud Tasks so we use onRequest.
-export const removeUnmatchedUserAfterTimeout = functions
-  .region(FUNCTION_LOCATION)
-  .https.onRequest(async (req: functions.Request, res: functions.Response) => {
+export const removeUnmatchedUserAfterTimeout = functionBuilder.https.onRequest(
+  async (req: functions.Request, res: functions.Response) => {
     functions.logger.info(`Received parameters ${JSON.stringify(req.body)}`);
 
     const data = req.body.data;
@@ -55,12 +54,12 @@ export const removeUnmatchedUserAfterTimeout = functions
       res.status(200).json({
         message: msg,
       });
+      return;
     }
 
     // If the user is not in a session, remove them from the queue
     const queueName = queueCore.validateAndGetLevel(data);
     if ((await queueCore.getQueueUserIsIn(userId)) !== queueName) {
-      functions.logger.info('C');
       res.status(400).json({
         code: 'failed-precondition',
         message: `UserId ${userId} is not in ${queueName} queue`,
@@ -78,12 +77,13 @@ export const removeUnmatchedUserAfterTimeout = functions
     functions.logger.info(`User ${userId} was removed from the queue`);
     res.status(200).json(SUCCESS_RESP);
     return;
-  });
+  }
+);
 
-export const getQueueUserIsIn = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (_data: any, context: CallableContext) => {
+export const getQueueUserIsIn = functionBuilder.https.onCall(
+  async (_data: any, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const queueName = await queueCore.getQueueUserIsIn(uid);
     return { queueName };
-  });
+  }
+);

--- a/backend/functions/src/sessions.ts
+++ b/backend/functions/src/sessions.ts
@@ -2,11 +2,11 @@ import * as functions from 'firebase-functions';
 import * as sessionCore from './core/sessionCore';
 import { validateAndGetUid } from './core/authCore';
 import { CallableContext } from 'firebase-functions/v1/https';
-import { SUCCESS_RESP, FUNCTION_LOCATION } from './consts/values';
+import { SUCCESS_RESP } from './consts/values';
+import functionBuilder from './functionBuilder';
 
-export const stopSession = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: any, context: CallableContext) => {
+export const stopSession = functionBuilder.https.onCall(
+  async (data: any, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const sessId = await sessionCore.getCurrentSessionId(uid);
 
@@ -19,27 +19,27 @@ export const stopSession = functions
 
     await sessionCore.endSession(sessId);
     return SUCCESS_RESP;
-  });
+  }
+);
 
-export const getCurrentSessionId = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: any, context: CallableContext) => {
+export const getCurrentSessionId = functionBuilder.https.onCall(
+  async (data: any, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const sessId = await sessionCore.getCurrentSessionId(uid);
     return { sessId };
-  });
+  }
+);
 
-export const isInCurrentSession = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: any, context: CallableContext) => {
+export const isInCurrentSession = functionBuilder.https.onCall(
+  async (data: any, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const res = await sessionCore.isInCurrentSession(uid);
     return { isInCurrentSession: res };
-  });
+  }
+);
 
-export const getSession = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: App.getSessionData, context: CallableContext) => {
+export const getSession = functionBuilder.https.onCall(
+  async (data: App.getSessionData, context: CallableContext) => {
     validateAndGetUid(context); // Only logged in users can get session data
 
     if (!data || !data.sessId) {
@@ -51,19 +51,19 @@ export const getSession = functions
 
     const sessId = data.sessId;
     return await sessionCore.getSession(sessId);
-  });
+  }
+);
 
-export const changeQuestionRequest = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: any, context: CallableContext) => {
+export const changeQuestionRequest = functionBuilder.https.onCall(
+  async (data: any, context: CallableContext) => {
     const currUid = validateAndGetUid(context);
     await sessionCore.processChangeQuestionRequest(currUid);
     return SUCCESS_RESP;
-  });
+  }
+);
 
-export const changeQuestion = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (_, context: CallableContext) => {
+export const changeQuestion = functionBuilder.https.onCall(
+  async (_, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     const sessId = await sessionCore.getCurrentSessionId(uid);
     if (!sessId) {
@@ -75,19 +75,19 @@ export const changeQuestion = functions
 
     await sessionCore.changeQuestionInSession(sessId);
     return SUCCESS_RESP;
-  });
+  }
+);
 
-export const rejectChangeQuestion = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (_, context: CallableContext) => {
+export const rejectChangeQuestion = functionBuilder.https.onCall(
+  async (_, context: CallableContext) => {
     const uid = validateAndGetUid(context);
     await sessionCore.rejectChangeQuestion(uid);
     return SUCCESS_RESP;
-  });
+  }
+);
 
-export const updateAndGetWriter = functions
-  .region(FUNCTION_LOCATION)
-  .https.onCall(async (data: any, context: CallableContext) => {
+export const updateAndGetWriter = functionBuilder.https.onCall(
+  async (data: any, context: CallableContext) => {
     validateAndGetUid(context); // Only logged in users can access session data
 
     if (!data || !data.sessId) {
@@ -100,4 +100,5 @@ export const updateAndGetWriter = functions
     const sessId = data.sessId;
     const writerId = await sessionCore.updateAndGetWriter(sessId);
     return { writerId };
-  });
+  }
+);

--- a/backend/functions/src/tasks/matchTimeout.ts
+++ b/backend/functions/src/tasks/matchTimeout.ts
@@ -7,6 +7,7 @@ import {
   USER_TIMEOUT_DURING_MATCH,
   REMOVE_UNMATCHED_USER_FUNCTION_URL,
 } from '../consts/tasks';
+import autoId from '../util/autoId';
 
 export async function addUserToTimeoutQueue(
   data: App.userTimeoutDetails
@@ -28,8 +29,13 @@ export async function addUserToTimeoutQueue(
     CLOUD_TASK_LOCATION,
     MATCH_TIMEOUT_QUEUE_NAME
   );
+
+  const taskId = autoId();
   const payload = {
-    data: data,
+    data: {
+      ...data,
+      taskId,
+    },
   };
 
   const task: any = {
@@ -51,5 +57,10 @@ export async function addUserToTimeoutQueue(
   functions.logger.info('Sending task:', task);
   const request = { parent: parent, task: task };
   const [response] = await client.createTask(request);
-  functions.logger.info(`Created task ${response.name}`);
+  functions.logger.info(
+    `Created task ${response.name} with generated taskId of ${taskId}`
+  );
+  return {
+    id: taskId,
+  };
 }

--- a/backend/functions/src/util/autoId.ts
+++ b/backend/functions/src/util/autoId.ts
@@ -1,0 +1,27 @@
+import { randomBytes } from 'crypto';
+
+// Adapted from https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/util/misc.ts
+function autoId(): string {
+  // Alphanumeric characters
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  // The largest byte value that is a multiple of `char.length`.
+  const maxMultiple = Math.floor(256 / chars.length) * chars.length;
+
+  let autoId = '';
+  const targetLength = 20;
+  while (autoId.length < targetLength) {
+    const bytes = randomBytes(40);
+    for (let i = 0; i < bytes.length; ++i) {
+      // Only accept values that are [0, maxMultiple), this ensures they can
+      // be evenly mapped to indices of `chars` via a modulo operation.
+      if (autoId.length < targetLength && bytes[i] < maxMultiple) {
+        autoId += chars.charAt(bytes[i] % chars.length);
+      }
+    }
+  }
+
+  return autoId;
+}
+
+export default autoId;

--- a/backend/functions/test/queues.test.ts
+++ b/backend/functions/test/queues.test.ts
@@ -1,6 +1,10 @@
 import * as admin from 'firebase-admin';
 import { queues } from '../src/index';
-import { createOnlineUser, createSession } from './testUtil/factory';
+import {
+  createMatchTimeoutTask,
+  createOnlineUser,
+  createSession,
+} from './testUtil/factory';
 import { expect } from './testUtil/chai';
 import fft from './testUtil/fft';
 
@@ -66,11 +70,13 @@ describe('removeUnmatchedUserAfterTimeout', () => {
     it('should exit successfully', async () => {
       const sess = await createSession();
       const userId1 = sess.users[0];
+      const matchTimeoutTask = await createMatchTimeoutTask(userId1);
       const req = {
         body: {
           data: {
             userId: userId1,
             queueName: 'easy',
+            taskId: matchTimeoutTask.taskId,
           },
         },
       };
@@ -93,6 +99,7 @@ describe('removeUnmatchedUserAfterTimeout', () => {
     it('should remove user from queue', async () => {
       const userId = await createOnlineUser();
       const db = admin.database();
+      const matchTimeoutTask = await createMatchTimeoutTask(userId);
       await db.ref('/queues/easy').set([userId]);
 
       const req = {
@@ -100,6 +107,7 @@ describe('removeUnmatchedUserAfterTimeout', () => {
           data: {
             userId,
             queueName: 'easy',
+            taskId: matchTimeoutTask.taskId,
           },
         },
       };

--- a/backend/functions/test/testUtil/factory.ts
+++ b/backend/functions/test/testUtil/factory.ts
@@ -8,21 +8,22 @@ const isOnlineForDatabase = {
   lastUpdated: admin.database.ServerValue.TIMESTAMP,
 };
 
+function generateId(): string {
+  let id = '';
+
+  for (let i = 0; i < 28; i++) {
+    id += ASCII_CHARS.charAt(Math.floor(Math.random() * ASCII_CHARS.length));
+  }
+
+  return id;
+}
+
 export async function setUserOnline(uid: string): Promise<void> {
   await admin.database().ref(`/status/${uid}`).set(isOnlineForDatabase);
 }
 
 export async function createUser(): Promise<string> {
-  // By default, user will be online
-  let userId = '';
-
-  for (let i = 0; i < 28; i++) {
-    userId += ASCII_CHARS.charAt(
-      Math.floor(Math.random() * ASCII_CHARS.length)
-    );
-  }
-
-  return userId;
+  return generateId();
 }
 
 export async function createOnlineUser(): Promise<string> {
@@ -53,4 +54,13 @@ export async function createSession(): Promise<App.Session> {
   }
 
   return sessData;
+}
+
+export async function createMatchTimeoutTask(userId: string): Promise<any> {
+  const firestore = admin.firestore();
+  const task = { taskId: generateId() };
+  await firestore
+    .doc(`matchTimeoutTasks/${userId}`)
+    .set({ taskId: task.taskId });
+  return task;
 }


### PR DESCRIPTION
Can set minInstances through functions env variables by doing 
`firebase functions:config:set peerprep.mininstances=2` to set 2 minInstances per function